### PR TITLE
Fixes and additions to make it work with dns-sd

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ import (
 
 func main() {
     // Run registration (blocking call)
-    exitCh, err := bonjour.RegisterProxy("Proxy Service", "_foobar._tcp", "", 9999, "octopus", "10.0.0.111", []string{"txtv=1", "app=test"}, nil)
+    s, err := bonjour.RegisterProxy("Proxy Service", "_foobar._tcp", "", 9999, "octopus", "10.0.0.111", []string{"txtv=1", "app=test"}, nil)
     if err != nil {
         log.Fatalln(err.Error())
     }
@@ -156,7 +156,7 @@ func main() {
     signal.Notify(handler, os.Interrupt)
     for sig := range handler {
         if sig == os.Interrupt {
-            exitCh <- true
+            s.Shutdown()
             time.Sleep(1e9)
             break
         }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ import (
 
 func main() {
     // Run registration (blocking call)
-    exitCh, err := bonjour.Register("Foo Service", "_foobar._tcp", "", 9999, []string{"txtv=1", "app=test"}, nil)
+    s, err := bonjour.Register("Foo Service", "_foobar._tcp", "", 9999, []string{"txtv=1", "app=test"}, nil)
     if err != nil {
         log.Fatalln(err.Error())
     }
@@ -121,7 +121,7 @@ func main() {
     signal.Notify(handler, os.Interrupt)
     for sig := range handler {
         if sig == os.Interrupt {
-            exitCh <- true
+            s.Shutdown()
             time.Sleep(1e9)
             break
         }

--- a/client.go
+++ b/client.go
@@ -316,8 +316,8 @@ func (c *client) sendQuery(msg *dns.Msg) error {
 	if c.ipv4conn != nil {
 		c.ipv4conn.WriteTo(buf, ipv4Addr)
 	}
-	if c.ipv4conn != nil {
-		c.ipv4conn.WriteTo(buf, ipv6Addr)
+	if c.ipv6conn != nil {
+		c.ipv6conn.WriteTo(buf, ipv6Addr)
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -553,8 +553,8 @@ func (c *server) multicastResponse(msg *dns.Msg) error {
 	if c.ipv4conn != nil {
 		c.ipv4conn.WriteTo(buf, ipv4Addr)
 	}
-	if c.ipv4conn != nil {
-		c.ipv4conn.WriteTo(buf, ipv6Addr)
+	if c.ipv6conn != nil {
+		c.ipv6conn.WriteTo(buf, ipv6Addr)
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/miekg/dns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"github.com/miekg/dns"
 )
 
 var (
@@ -506,6 +506,7 @@ func (s *server) probe() {
 	}
 
 	resp := new(dns.Msg)
+	resp.MsgHdr.Response = true
 	resp.Answer = []dns.RR{}
 	resp.Extra = []dns.RR{}
 	s.composeLookupAnswers(resp, 3200)
@@ -519,6 +520,7 @@ func (s *server) probe() {
 
 func (s *server) unregister() error {
 	resp := new(dns.Msg)
+	resp.MsgHdr.Response = true
 	resp.Answer = []dns.RR{}
 	resp.Extra = []dns.RR{}
 	s.composeLookupAnswers(resp, 0)

--- a/server.go
+++ b/server.go
@@ -312,7 +312,7 @@ func (s *server) handleQuery(query *dns.Msg, from net.Addr) error {
 			if len(resp.Answer) > 0 {
 				if isUnicastQuestion(q) {
 					// Send unicast
-					if e := s.sendResponse(&resp, from); e != nil {
+					if e := s.unicastResponse(&resp, from); e != nil {
 						err = e
 					}
 				} else {
@@ -589,8 +589,8 @@ func (s *server) unregister() error {
 	return s.multicastResponse(resp)
 }
 
-// sendResponse is used to send a unicast response packet
-func (s *server) sendResponse(resp *dns.Msg, from net.Addr) error {
+// unicastResponse is used to send a unicast response packet
+func (s *server) unicastResponse(resp *dns.Msg, from net.Addr) error {
 	buf, err := resp.Pack()
 	if err != nil {
 		return err

--- a/service.go
+++ b/service.go
@@ -14,6 +14,7 @@ type ServiceRecord struct {
 	// private variable populated on the first call to ServiceName()/ServiceInstanceName()
 	serviceName         string `json:"-"`
 	serviceInstanceName string `json:"-"`
+	serviceTypeName     string `json:"-"`
 }
 
 // Returns complete service name (e.g. _foobar._tcp.local.), which is composed
@@ -39,9 +40,21 @@ func (s *ServiceRecord) ServiceInstanceName() string {
 	return s.serviceInstanceName
 }
 
+func (s *ServiceRecord) ServiceTypeName() string {
+	// If not cached - compose and cache
+	if s.serviceTypeName == "" {
+		domain := "local"
+		if len(s.Domain) > 0 {
+			domain = trimDot(s.Domain)
+		}
+		s.serviceTypeName = fmt.Sprintf("_services._dns-sd._udp.%s.", domain)
+	}
+	return s.serviceTypeName
+}
+
 // Constructs a ServiceRecord structure by given arguments
 func NewServiceRecord(instance, service, domain string) *ServiceRecord {
-	return &ServiceRecord{instance, service, domain, "", ""}
+	return &ServiceRecord{instance, service, domain, "", "", ""}
 }
 
 // LookupParams contains configurable properties to create a service discovery request


### PR DESCRIPTION
I'm using this library with my changes pretty heavily and it works reliably enough that I would like to see my changes in the main repo.
Here is what changed and why.

## Server

*Fixes*

- Send unicast responds if requested (`server.go:315`)

- `Register()` now returns a `Server` instance because the server shutdown is done by calling `Shutdown()` instead of using the shutdown channel. 

Problem with a shutdown channel arises when it's not clear how long the shutdown will take because the shutdown process runs in a separate goroutine. It may happen that the program terminates before the server was able to send *goodbye* packets. This can be prevented by calling `Shutdown()`.

*Additions*

- Send unsolicited responses during probing (`server.go:547`)

- Set the cache flush bit in `composeLookupAnswers()` (`server.go:411`)

- `SetText()` update and reannounces TXT records

- Respond to`_services._dns-sd._udp.<domain>` dns query (`server.go:343`)

> A DNS query for PTR records with the name "_services._dns-sd._udp." yields a set of PTR records, where the rdata of each PTR record is the two-label name, plus the same domain, e.g. "_http._tcp.". From [mDNS RFC](https://tools.ietf.org/html/rfc6762)

## Client

- Correctly send to ipv6 connection
