### PR TITLE
Fix for udp6 binding error

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,7 +27,7 @@ func NewResolver(iface *net.Interface) (*Resolver, error) {
 	return &Resolver{c, c.closedCh}, nil
 }
 
-// Browse for all services of a fiven type in a given domain
+// Browse for all services of a given type in a given domain
 func (r *Resolver) Browse(service, domain string, entries chan<- *ServiceEntry) error {
 	params := defaultParams(service)
 	if domain != "" {

--- a/server.go
+++ b/server.go
@@ -26,7 +26,7 @@ var (
 		Port: 5353,
 	}
 	mdnsWildcardAddrIPv6 = &net.UDPAddr{
-		IP:   net.ParseIP("[ff02::]"),
+		IP:   net.ParseIP("ff02::"),
 		Port: 5353,
 	}
 


### PR DESCRIPTION
The following observed error fixed:
[ERR] bonjour: Failed to bind to udp6 port: listen udp6 :5353: bind: address already in use