### PR TITLE
Add support for broadcasting multiple IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ import (
 
 func main() {
     // Run registration (blocking call)
-    s, err := bonjour.Register("Foo Service", "_foobar._tcp", "", 9999, []string{"txtv=1", "app=test"}, nil)
+    s, err := bonjour.Register("Foo Service", "_foobar._tcp", "", 9999, []string{"txtv=1", "app=test"}, nil, 0)
     if err != nil {
         log.Fatalln(err.Error())
     }
@@ -146,7 +146,7 @@ import (
 
 func main() {
     // Run registration (blocking call)
-    s, err := bonjour.RegisterProxy("Proxy Service", "_foobar._tcp", "", 9999, "octopus", "10.0.0.111", []string{"txtv=1", "app=test"}, nil)
+    s, err := bonjour.RegisterProxy("Proxy Service", "_foobar._tcp", "", 9999, "octopus", "10.0.0.111", []string{"txtv=1", "app=test"}, nil, 0)
     if err != nil {
         log.Fatalln(err.Error())
     }

--- a/client.go
+++ b/client.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/miekg/dns"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"github.com/miekg/dns"
 )
 
 // Main client data structure to run browse/lookup queries
@@ -203,13 +203,13 @@ func (c *client) mainloop(params *LookupParams) {
 				case *dns.A:
 					for k, e := range entries {
 						if e.HostName == rr.Hdr.Name && entries[k].AddrIPv4 == nil {
-							entries[k].AddrIPv4 = rr.A
+							entries[k].AddrIPv4 = append(entries[k].AddrIPv4, rr.A)
 						}
 					}
 				case *dns.AAAA:
 					for k, e := range entries {
 						if e.HostName == rr.Hdr.Name && entries[k].AddrIPv6 == nil {
-							entries[k].AddrIPv6 = rr.AAAA
+							entries[k].AddrIPv6 = append(entries[k].AddrIPv6, rr.AAAA)
 						}
 					}
 				}

--- a/service.go
+++ b/service.go
@@ -80,8 +80,8 @@ type ServiceEntry struct {
 	Port     int      `json:"port"`     // Service Port
 	Text     []string `json:"text"`     // Service info served as a TXT record
 	TTL      uint32   `json:"ttl"`      // TTL of the service record
-	AddrIPv4 net.IP   `json:"-"`        // Host machine IPv4 address
-	AddrIPv6 net.IP   `json:"-"`        // Host machine IPv6 address
+	AddrIPv4 []net.IP `json:"-"`        // Host machine IPv4 address
+	AddrIPv6 []net.IP `json:"-"`        // Host machine IPv6 address
 }
 
 // Constructs a ServiceEntry structure by given arguments
@@ -92,7 +92,7 @@ func NewServiceEntry(instance, service, domain string) *ServiceEntry {
 		0,
 		[]string{},
 		0,
-		nil,
-		nil,
+		[]net.IP{},
+		[]net.IP{},
 	}
 }


### PR DESCRIPTION
* Allows you to broadcast multiple A/AAAA records
* Allows you to set TTL before broadcasts begin

Despite this, I'm not convinced that TTLs are implemented correctly in the original package -- they seem to be time based and not hop-based. As I understand, Bonjour is supposed to be a TTL of 1 so it never leaves your subnet. Would love guidance on this from someone more knowledgeable.