### PR TITLE
only send packets to the selected interface, not all interfaces

### DIFF
--- a/server.go
+++ b/server.go
@@ -183,7 +183,13 @@ func newServer(iface *net.Interface) (*Server, error) {
 		if err := p1.JoinGroup(iface, &net.UDPAddr{IP: mdnsGroupIPv4}); err != nil {
 			return nil, err
 		}
+		if err := p1.SetMulticastInterface(iface); err != nil {
+			return nil, err
+		}
 		if err := p2.JoinGroup(iface, &net.UDPAddr{IP: mdnsGroupIPv6}); err != nil {
+			return nil, err
+		}
+		if err := p2.SetMulticastInterface(iface); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
In the current implementation, the `ipv{4,6}conn` is bound to `224.0.0.1:5353` which works out to `0.0.0.0:5353` when you ask the connection's `LocalAddr()` method. Accordingly, multicast writes go out to *all* interfaces of the host.

I have a situation where I announce my services on two different network interfaces, each of which has its own IP address. As all packets are sent to all interfaces, one of the updates will win and it will not always be the right one.

In this pull request I added calls to `*ipv{4,6}.PacketConn.SetMulticastInterface`. This makes the underlying `*net.UDPConn`s send out multicast packets on only the specified interface, thereby correcting the behavior.

Thanks for writing this library :)